### PR TITLE
GUARD-585 Change date conversion hours from 12-hours to 24-hours

### DIFF
--- a/src/NewEggAccess/NewEggAccess.csproj
+++ b/src/NewEggAccess/NewEggAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/newEggAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/newEggAccess</RepositoryUrl>
-    <Version>1.0.3.0-alpha</Version>
+    <Version>1.0.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/src/NewEggAccess/NewEggAccess.csproj
+++ b/src/NewEggAccess/NewEggAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/newEggAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/newEggAccess</RepositoryUrl>
-    <Version>1.0.4.0</Version>
+    <Version>1.0.5.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.4.0</AssemblyVersion>
-    <FileVersion>1.0.4.0</FileVersion>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <FileVersion>1.0.5.0</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/src/NewEggAccess/Shared/Misc.cs
+++ b/src/NewEggAccess/Shared/Misc.cs
@@ -43,7 +43,8 @@ namespace NewEggAccess.Shared
 
 		public static string ConvertFromUtcToPstStr( DateTime date )
 		{
-			return TimeZoneInfo.ConvertTimeBySystemTimeZoneId( date, "Pacific Standard Time" ).ToString( "yyyy-MM-dd hh:mm:ss" );
+			var pacitificDateTime = TimeZoneInfo.ConvertTimeBySystemTimeZoneId( date, "Pacific Standard Time" );
+			return pacitificDateTime.ToString( "yyyy-MM-dd HH:mm:ss" );
 		}
 
 		public static DateTime ConvertFromPstToUtc( DateTime date )

--- a/src/NewEggAccess/Shared/Misc.cs
+++ b/src/NewEggAccess/Shared/Misc.cs
@@ -43,8 +43,8 @@ namespace NewEggAccess.Shared
 
 		public static string ConvertFromUtcToPstStr( DateTime date )
 		{
-			var pacitificDateTime = TimeZoneInfo.ConvertTimeBySystemTimeZoneId( date, "Pacific Standard Time" );
-			return pacitificDateTime.ToString( "yyyy-MM-dd HH:mm:ss" );
+			var pacificDateTime = TimeZoneInfo.ConvertTimeBySystemTimeZoneId( date, "Pacific Standard Time" );
+			return pacificDateTime.ToString( "yyyy-MM-dd HH:mm:ss" );
 		}
 
 		public static DateTime ConvertFromPstToUtc( DateTime date )

--- a/src/NewEggTests/DateTimeConversionTests.cs
+++ b/src/NewEggTests/DateTimeConversionTests.cs
@@ -1,0 +1,67 @@
+﻿using FluentAssertions;
+using NewEggAccess.Shared;
+using NUnit.Framework;
+using System;
+
+namespace NewEggTests
+{
+	[ TestFixture ]
+	public class DateTimeConversionTests
+	{
+		private const int pacificUtcDiffDaylightSavings = -7;
+
+		[ Test ]
+		public void ConvertFromUtcToPstStr()
+		{
+			const int Year = 2020;
+			const int Month = 5;
+			const int Day = 6;
+			const int Hour = 20;
+			const int Minute = 2;
+			var utcDate = new DateTime( Year, Month, Day, Hour, Minute, 1, DateTimeKind.Utc ); 
+
+			var pacificDate = DateTime.Parse( Misc.ConvertFromUtcToPstStr( utcDate ) );
+
+			pacificDate.Year.Should().Be( Year );
+			pacificDate.Month.Should().Be( Month );
+			pacificDate.Day.Should().Be( Day );
+			pacificDate.Hour.Should().Be( Hour + pacificUtcDiffDaylightSavings );
+			pacificDate.Minute.Should().Be( Minute );
+		}
+
+		[ Test ]
+		public void ConvertFromUtcToPstStr_PacificAfterNoon()
+		{
+			const int Hour = 20;
+			var utcAfter8PM = new DateTime( 2020, 5, 6, Hour, 0, 1, DateTimeKind.Utc ); 
+
+			var pacificAfterNoon = Misc.ConvertFromUtcToPstStr( utcAfter8PM );
+
+			DateTime.Parse( pacificAfterNoon ).Hour.Should().Be( Hour + pacificUtcDiffDaylightSavings );
+		}
+
+		[ Test ]
+		public void ConvertFromUtcToPstStr_PacificAfterMidnight()
+		{
+			const int Hour = 7;
+			var utcAfter7AM = new DateTime( 2020, 5, 6, Hour, 0, 1, DateTimeKind.Utc ); 
+
+			var pacificAfterMidnight = Misc.ConvertFromUtcToPstStr( utcAfter7AM );
+
+			DateTime.Parse( pacificAfterMidnight ).Hour.Should().Be( Hour + pacificUtcDiffDaylightSavings );
+		}
+
+		[ Test ]
+		public void ConvertFromUtcToPstStr_PacificBeforeMidnightPrevDay()
+		{
+			const int Hour = 6;
+			const int Day = 6;
+			var utcAfter7AM = new DateTime( 2020, 5, Day, Hour, 0, 1, DateTimeKind.Utc ); 
+
+			var pacificAfterMidnight = Misc.ConvertFromUtcToPstStr( utcAfter7AM );
+
+			DateTime.Parse( pacificAfterMidnight ).Hour.Should().Be( Hour + pacificUtcDiffDaylightSavings + 24 );
+			DateTime.Parse( pacificAfterMidnight ).Day.Should().Be( Day - 1);
+		}
+	}
+}

--- a/src/NewEggTests/DateTimeConversionTests.cs
+++ b/src/NewEggTests/DateTimeConversionTests.cs
@@ -35,9 +35,9 @@ namespace NewEggTests
 			const int Hour = 20;
 			var utcAfter8PM = new DateTime( 2020, 5, 6, Hour, 0, 1, DateTimeKind.Utc ); 
 
-			var pacificAfterNoon = Misc.ConvertFromUtcToPstStr( utcAfter8PM );
+			var pacificAfternoon = Misc.ConvertFromUtcToPstStr( utcAfter8PM );
 
-			DateTime.Parse( pacificAfterNoon ).Hour.Should().Be( Hour + pacificUtcDiffDaylightSavings );
+			DateTime.Parse( pacificAfternoon ).Hour.Should().Be( Hour + pacificUtcDiffDaylightSavings );
 		}
 
 		[ Test ]

--- a/src/NewEggTests/NewEggTests.csproj
+++ b/src/NewEggTests/NewEggTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="BaseTest.cs" />
     <Compile Include="FeedsTests.cs" />
     <Compile Include="ItemTests.cs" />
+    <Compile Include="DateTimeConversionTests.cs" />
     <Compile Include="OrderMapperTests.cs" />
     <Compile Include="OrderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
The conversion formatter was using the 12-hour hours, even though there's no AM/PM. Changing to 24-hour hours fixed it. Added failing tests. Then fixed the issue and tests now pass.